### PR TITLE
Added isort, flake8 and mypy

### DIFF
--- a/.github/workflows/service-build-test-upload.yml
+++ b/.github/workflows/service-build-test-upload.yml
@@ -105,6 +105,11 @@ jobs:
         run: |
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} black --target-version py310 -S --check /usr/src/app
 
+      - name: Run flake8
+        if : steps.changed-py-files.outputs.any_changed == 'true'
+        run: |
+          docker run --entrypoint "" ${{ env.IMAGE_NAME }} flake8 ${{ steps.changed-py-files.outputs.all_changed_files }}
+
       - name: Run tests
         run: |
           docker run -e "DJANGO_DUMMY_ENV=True" -e POSTGRES_HOST="localhost" \

--- a/.github/workflows/service-build-test-upload.yml
+++ b/.github/workflows/service-build-test-upload.yml
@@ -106,21 +106,22 @@ jobs:
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} black --target-version py310 -S --check /usr/src/app
 
       - name: Run isort
-        if: steps.changed-py-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' && success() || failure() }}
         run: |
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} isort --check-only --profile black ${{ steps.changed-py-files.outputs.all_changed_files }}
 
       - name: Run flake8
-        if: steps.changed-py-files.outputs.any_changed == 'true'
+        if: ${{steps.changed-py-files.outputs.any_changed == 'true' && success() || failure() }}
         run: |
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} flake8 ${{ steps.changed-py-files.outputs.all_changed_files }}
 
       - name: Run mypy
-        if: steps.changed-py-files.outputs.any_changed == 'true'
+        if: ${{ steps.changed-py-files.outputs.any_changed == 'true' && success() || failure() }}
         run: |
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --follow-imports=silent  --install-types --non-interactive
 
       - name: Run tests
+        if: success()
         run: |
           docker run -e "DJANGO_DUMMY_ENV=True" -e POSTGRES_HOST="localhost" \
           -e POSTGRES_PASSWORD -e POSTGRES_DB -e POSTGRES_USER \

--- a/.github/workflows/service-build-test-upload.yml
+++ b/.github/workflows/service-build-test-upload.yml
@@ -118,7 +118,7 @@ jobs:
       - name: Run mypy
         if: ${{ steps.changed-py-files.outputs.any_changed == 'true' && success() || failure() }}
         run: |
-          docker run --entrypoint "" ${{ env.IMAGE_NAME }} mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --follow-imports=silent  --install-types --non-interactive
+          docker run --entrypoint "" ${{ env.IMAGE_NAME }} mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --follow-imports=silent --non-interactive
 
       - name: Run tests
         if: success()

--- a/.github/workflows/service-build-test-upload.yml
+++ b/.github/workflows/service-build-test-upload.yml
@@ -105,10 +105,20 @@ jobs:
         run: |
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} black --target-version py310 -S --check /usr/src/app
 
+      - name: Run isort
+        if: steps.changed-py-files.outputs.any_changed == 'true'
+        run: |
+          docker run --entrypoint "" ${{ env.IMAGE_NAME }} isort --check-only --profile black ${{ steps.changed-py-files.outputs.all_changed_files }}
+
       - name: Run flake8
-        if : steps.changed-py-files.outputs.any_changed == 'true'
+        if: steps.changed-py-files.outputs.any_changed == 'true'
         run: |
           docker run --entrypoint "" ${{ env.IMAGE_NAME }} flake8 ${{ steps.changed-py-files.outputs.all_changed_files }}
+
+      - name: Run mypy
+        if: steps.changed-py-files.outputs.any_changed == 'true'
+        run: |
+          docker run --entrypoint "" ${{ env.IMAGE_NAME }} mypy ${{ steps.changed-py-files.outputs.all_changed_files }} --follow-imports=silent  --install-types --non-interactive
 
       - name: Run tests
         run: |


### PR DESCRIPTION
This functionality should live in a separate branch and mustn't be merged into master because in that case it will broke a lot of pipelines
For now to use pipeline with isort, flake8 and mypy you should set **mint-ai/be-workflows/.github/workflows/service-build-test-upload.yml@main@feature/isort-flake8-mypy** in project's build-test-upload.yml