### PR TITLE
Fetch full history for sonar

### DIFF
--- a/.github/workflows/service-build-test-upload.yml
+++ b/.github/workflows/service-build-test-upload.yml
@@ -71,6 +71,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Set IMAGE_NAME
         run: |

--- a/.github/workflows/service-druid-build-test-upload.yml
+++ b/.github/workflows/service-druid-build-test-upload.yml
@@ -49,6 +49,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Set IMAGE_NAME
         run: |

--- a/.github/workflows/service-scala-build-test-upload.yml
+++ b/.github/workflows/service-scala-build-test-upload.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
 
       - name: Set IMAGE_NAME
         run: |


### PR DESCRIPTION
When sonar has no access to base branch of PR, it analysis all the target branch issues, which basically blocks the PR if there any previous issues in the old code.

Fetching all the history with `fetch-depth: 0` is not the perfect solution (a lot of excess information which slows the build), but decent one for the time being.