### PR TITLE
Update sonarqube-scan-action version

### DIFF
--- a/.github/workflows/service-build-test-upload.yml
+++ b/.github/workflows/service-build-test-upload.yml
@@ -134,7 +134,7 @@ jobs:
 
       - name: Sonarqube
         if: ${{ inputs.sonar && (github.actor != 'dependabot[bot]') }}
-        uses: sonarsource/sonarqube-scan-action@v4.1.0
+        uses: sonarsource/sonarqube-scan-action@v4.2.1
         env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/service-druid-build-test-upload.yml
+++ b/.github/workflows/service-druid-build-test-upload.yml
@@ -122,7 +122,7 @@ jobs:
 
       - name: Sonarqube
         if: ${{ inputs.sonar && (github.actor != 'dependabot[bot]') }}
-        uses: sonarsource/sonarqube-scan-action@v4.1.0
+        uses: sonarsource/sonarqube-scan-action@v4.2.1
         env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 

--- a/.github/workflows/service-scala-build-test-upload.yml
+++ b/.github/workflows/service-scala-build-test-upload.yml
@@ -100,7 +100,7 @@ jobs:
 
       - name: Sonarqube
         if: ${{ inputs.sonar && (github.actor != 'dependabot[bot]') }}
-        uses: sonarsource/sonarqube-scan-action@v4.1.0
+        uses: sonarsource/sonarqube-scan-action@v4.2.1
         env:
             SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
 


### PR DESCRIPTION
The module version was updated due to an error, since it has actions/cache

Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v4.0.2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down